### PR TITLE
Task 7 (Authorization)

### DIFF
--- a/src/app/admin/manage-products/manage-products.service.ts
+++ b/src/app/admin/manage-products/manage-products.service.ts
@@ -31,8 +31,16 @@ export class ManageProductsService extends ApiService {
 
   private getPreSignedUrl(fileName: string): Observable<string> {
     const url = this.getUrl('import', 'import');
+    const headers: Record<string, string> = {};
+
+    if (localStorage.getItem('authorization_token')) {
+      headers.Authorization = `Basic ${btoa(
+        localStorage.getItem('authorization_token') as string
+      )}`;
+    }
 
     return this.http.get<string>(url, {
+      headers,
       params: {
         name: fileName,
       },

--- a/src/app/core/interceptors/error-print.interceptor.ts
+++ b/src/app/core/interceptors/error-print.interceptor.ts
@@ -19,13 +19,34 @@ export class ErrorPrintInterceptor implements HttpInterceptor {
   ): Observable<HttpEvent<unknown>> {
     return next.handle(request).pipe(
       tap({
-        error: () => {
+        error: (event: unknown) => {
           const url = new URL(request.url);
 
-          this.notificationService.showError(
-            `Request to "${url.pathname}" failed. Check the console for the details`,
-            0
-          );
+          switch ((event as any).status) {
+            case 401: {
+              this.notificationService.showError(
+                'You are not authorized to access this page.',
+                3000
+              );
+              break;
+            }
+
+            case 403: {
+              this.notificationService.showError(
+                'You are not authorized to access this page.',
+                3000
+              );
+              break;
+            }
+
+            default: {
+              this.notificationService.showError(
+                `Request to "${url.pathname}" failed. Check the console for the details`,
+                0
+              );
+              break;
+            }
+          }
         },
       })
     );


### PR DESCRIPTION
### [Task 7 (Authorization)](https://github.com/EPAM-JS-Competency-center/cloud-development-course-initial/blob/main/7_authorization/task.md)
### Links
[Cloudfront](https://d38kp9bnq4apx6.cloudfront.net/) / [lambda endpoint](https://0nasdwjlua.execute-api.us-east-1.amazonaws.com/dev) / [frontend pr](https://github.com/mtctxd/shop-angular-cloudfront/pull/5) / [be pr](https://github.com/mtctxd/my-shop-server/pull/5) / [signed URL for import](https://2narrlsywd.execute-api.us-east-1.amazonaws.com/dev/import)

Additional tasks that should be done: 
+30 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file.
![image](https://user-images.githubusercontent.com/94276879/227705648-e0d96e2a-4ee0-42d9-b0b1-30518b70d60c.png)
![image](https://user-images.githubusercontent.com/94276879/227705659-19a5d659-f558-456c-b944-db3b65bad5b2.png)
